### PR TITLE
fixed calculation of messageLength.

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1253,7 +1253,7 @@ jQuery.atmosphere = function () {
                     var messageStart = message.indexOf(request.messageDelimiter);
                     while (messageStart != -1) {
                         var str = jQuery.trim(message.substring(0, messageStart));
-                        var messageLength = parseInt(str);
+                        var messageLength = parseInt(str, 10);
                         if (isNaN(messageLength))
                             throw 'message length "'+str+'" is not a number';
                         messageStart += request.messageDelimiter.length;


### PR DESCRIPTION
Otherwise e.g "08" will be parsed as octal 8 instead of the needed string representation. see https://github.com/Atmosphere/atmosphere-javascript/commit/6d2d27ff7b11693f3e37c9bc774be87f271786be#commitcomment-3426339
