### PR TITLE
Fix addCallback() method in atmosphere.js: added missing inArray() funct...

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2542,6 +2542,19 @@
 			return Object.prototype.toString.call(array) === "[object Array]";
 		},
 		
+		inArray: function(elem, array) {
+			if (!Array.prototype.indexOf) {
+				var len = array.length;
+				for (var i = 0; i < len; ++i) {
+					if (array[i] === elem) {
+						return i;
+					}
+				}
+				return -1;
+			}
+			return array.indexOf(elem);
+		},
+		
 		isBinary: function(data) {
 			var string = Object.prototype.toString.call(data);
 			return string === "[object Blob]" || string === "[object ArrayBuffer]";


### PR DESCRIPTION
...ion.

If we try to add a callback to the subscribe function (doing `socket.subscribe(request, myCallback);`), we get the following error:
Uncaught TypeError: Object #<Object> has no method 'inArray' atmosphere.js:2514

Added the `inArray()` method with support of IE <= 8.
