### PR TITLE
Fixed: Firefox needs the XHR to be async when using withCredentials=true

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2161,6 +2161,7 @@
                 rq.transport = "polling";
                 rq.method = "GET";
                 rq.async = false;
+                rq.withCredentials = false;
                 rq.reconnect = false;
                 rq.force = true;
                 rq.suspend = false;
@@ -2260,6 +2261,7 @@
                     logLevel: 'info',
                     requestCount: 0,
                     withCredentials: _request.withCredentials,
+                    async: _request.async,
                     transport: 'polling',
                     isOpen: true,
                     attachHeadersAsQueryString: true,


### PR DESCRIPTION
So here I force the POST request to have the same `async` param than the GET.
And I force `withCredentials=false` on closing.

It works without modification for the jQuery version because you always make async requests:
l.1712 `ajaxRequest.open(request.method, url, true);`

Thanks,
Sylvain.
