### PR TITLE
Only call onopen after the connection has actually been opened

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1677,10 +1677,6 @@
                         _timeout(_request);
 
                         if (rq.transport !== 'polling') {
-                            if ((!rq.enableProtocol || !request.firstMessage) && ajaxRequest.readyState === 2) {
-                                _triggerOpen(rq);
-                            }
-
                             // MSIE 9 and lower status can be higher than 1000, Chrome can be 0
                             var status = 200;
                             if (ajaxRequest.readyState === 4) {
@@ -1694,6 +1690,12 @@
                                 reconnectF();
                                 return;
                             }
+
+                            // Firefox incorrectly send statechange 0->2 when a reconnect attempt fails. The above checks ensure that onopen is not called for these
+                            if ((!rq.enableProtocol || !request.firstMessage) && ajaxRequest.readyState === 2) {
+                                _triggerOpen(rq);
+                            }
+
                         } else if (ajaxRequest.readyState === 4) {
                             update = true;
                         }

--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1595,9 +1595,6 @@ jQuery.atmosphere = function () {
                         _timeout(_request);
 
                         if (rq.transport !== 'polling') {
-                            if ((!rq.enableProtocol || !request.firstMessage) && ajaxRequest.readyState === 2) {
-                                _triggerOpen(rq);
-                            }
                             // MSIE 9 and lower status can be higher than 1000, Chrome can be 0
                             var status = 200;
                             if (ajaxRequest.readyState === 4) {
@@ -1610,6 +1607,11 @@ jQuery.atmosphere = function () {
                                 _clearState();
                                 reconnectF();
                                 return;
+                            }
+                            
+                            // Firefox incorrectly send statechange 0->2 when a reconnect attempt fails. The above checks ensure that onopen is not called for these
+                            if ((!rq.enableProtocol || !request.firstMessage) && ajaxRequest.readyState === 2) {
+                                _triggerOpen(rq);
                             }
                         } else if (ajaxRequest.readyState === 4) {
                             update = true;


### PR DESCRIPTION
Firefox likes to do readystatechange events (0->2) when reconnecting fails but these attempts have status==0 (as opposed to 200) and should not trigger onopen.

Related to #15, fixes http://dev.vaadin.com/ticket/12492
