### PR TITLE
honor configuration parameter request.webSocketUrl

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1098,7 +1098,7 @@
              * @private
              */
             function _buildWebSocketUrl() {
-                return _attachHeaders(_request, atmosphere.util.getAbsoluteURL(_request.url)).replace(/^http/, "ws");
+                return _attachHeaders(_request, atmosphere.util.getAbsoluteURL(_request.webSocketUrl || _request.url)).replace(/^http/, "ws");
             }
 
             /**


### PR DESCRIPTION
Checks if request.webSocketUrl has been configured (like described in documentation) and use this one if exists instead of request.url. This patch is for the non-jquery version only.
