### PR TITLE
Added _onError call for errors between 300 & 600

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1851,6 +1851,11 @@
                             if (ajaxRequest.readyState === 4) {
                                 status = ajaxRequest.status > 1000 ? 0 : ajaxRequest.status;
                             }
+                            
+                            if (status >= 300 && status < 600) {
+                                _onError(status, ajaxRequest.statusText);
+                                return;
+                            }
 
                             if (status >= 300 || status === 0) {
                                 disconnected();


### PR DESCRIPTION
This was done to allow 403 status to get handled by onError.  This pull request was request @jfarcand  on #114 
