### PR TITLE
Fix closeAsync, take the param from _request, not rq (it does not exists...

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -435,7 +435,7 @@
                     if (_request.enableXDR) {
                         closeR.enableXDR = _request.enableXDR
                     }
-                    closeR.async = rq.closeAsync;
+                    closeR.async = _request.closeAsync;
                     _pushOnClose("", closeR);
                 }
             }


### PR DESCRIPTION
Fix closeAsync, take the param from _request, not rq (it does not exists there)
