### PR TITLE
Update the websocket connection creation with second parameter to pass protocol

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1151,7 +1151,7 @@
                     return _request.webSocketImpl;
                 } else {
                     if (window.WebSocket) {
-                        return new WebSocket(location);
+                        return new WebSocket(location, _request.headers['Sec-WebSocket-Protocol']);
                     } else {
                         return new MozWebSocket(location);
                     }

--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1065,7 +1065,7 @@
                     return _request.webSocketImpl;
                 } else {
                     if (window.WebSocket) {
-                        return new WebSocket(location);
+                        return new WebSocket(location, _request.headers['Sec-WebSocket-Protocol']);
                     } else {
                         return new MozWebSocket(location);
                     }


### PR DESCRIPTION
Add the second parameter for protocol to creation of WebSocket instance. Without this, the ''Sec-WebSocket-Protocol" is passed as undefined leading to failure of WebSocket connection handshake 
