### PR TITLE
atmosphere-javascript#143:  Unsubscribe from beforeunload to avoid firef...

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -3379,6 +3379,13 @@
     })();
 
     atmosphere.util.on(window, "unload", function (event) {
+        atmosphere.util.debug(new Date() + " Atmosphere: " + "unload event");
+        atmosphere.unsubscribe();
+    });
+
+    // Temp fix for https://github.com/Atmosphere/atmosphere-javascript/issues/143
+    atmosphere.util.on(window, "beforeunload", function (event) {
+        atmosphere.util.debug(new Date() + " Atmosphere: " + "beforeunload event");
         atmosphere.unsubscribe();
     });
 

--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -37,6 +37,13 @@
 }(function(jQuery) {
 
     jQuery(window).bind("unload.atmosphere", function () {
+        jQuery.atmosphere.util.debug(new Date() + " Atmosphere: " + "unload event");
+        jQuery.atmosphere.unsubscribe();
+    });
+
+    // Temp fix for https://github.com/Atmosphere/atmosphere-javascript/issues/143
+    jQuery(window).bind("beforeunload.atmosphere", function () {
+        jQuery.atmosphere.util.debug(new Date() + " Atmosphere: " + "beforeunload event");
         jQuery.atmosphere.unsubscribe();
     });
 


### PR DESCRIPTION
Unsubscribe from beforeunload to avoid firefox reconnect before close on navigation away from current page. Also added some debug logging to these events.

NOTE: Not removed unsubscribe from unload event yet.
NOTE: The jquery change has not been tested as I don't use it..