### PR TITLE
Run jQuery.trim less when transport type isn't long-polling

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1900,7 +1900,7 @@
                         if (update) {
                             var responseText = ajaxRequest.responseText;
 
-                            if (jQuery.trim(responseText).length === 0 && rq.transport === 'long-polling') {
+                            if (rq.transport === 'long-polling' && jQuery.trim(responseText).length === 0) {
                                 // For browser that aren't support onabort
                                 if (!ajaxRequest.hasData) {
                                     reconnectF(true);


### PR DESCRIPTION
I was profiling an application i'm developing on and noticed that jQuery.trim was being run a lot.
I noticed this line and flipped the condition to test for transport type first so that clients that are not running long-polling (in my case it was streaming) don't have to jQuery.trim responseText as much.