### PR TITLE
Clear previous reconnect timer if one already exists

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1519,6 +1519,10 @@
                         if (_requestCount++ < _request.maxReconnectOnClose) {
                             _open('re-connecting', _request.transport, _request);
                             if (_request.reconnectInterval > 0) {
+                                if(_request.reconnectId) {
+                                    clearTimeout(_request.reconnectId);
+                                    delete _request.reconnectId;
+                                }
                                 _request.reconnectId = setTimeout(function () {
                                     _response.responseBody = "";
                                     _response.messages = [];

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -486,6 +486,12 @@
                 if (_request.heartbeatTimer) {
                     clearTimeout(_request.heartbeatTimer);
                 }
+                
+				//fix proposed by jfarcand in https://github.com/Atmosphere/atmosphere/issues/1860#issuecomment-74707226
+                if(_request.reconnectId) {
+                    clearTimeout(_request.reconnectId);
+                    delete _request.reconnectId;
+                }
 
                 if (_ieStream != null) {
                     _ieStream.close();

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -487,7 +487,7 @@
                     clearTimeout(_request.heartbeatTimer);
                 }
                 
-				//fix proposed by jfarcand in https://github.com/Atmosphere/atmosphere/issues/1860#issuecomment-74707226
+                //fix proposed by jfarcand in https://github.com/Atmosphere/atmosphere/issues/1860#issuecomment-74707226
                 if(_request.reconnectId) {
                     clearTimeout(_request.reconnectId);
                     delete _request.reconnectId;

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1525,10 +1525,6 @@
                         if (_requestCount++ < _request.maxReconnectOnClose) {
                             _open('re-connecting', _request.transport, _request);
                             if (_request.reconnectInterval > 0) {
-                                if(_request.reconnectId) {
-                                    clearTimeout(_request.reconnectId);
-                                    delete _request.reconnectId;
-                                }
                                 _request.reconnectId = setTimeout(function () {
                                     _response.responseBody = "";
                                     _response.messages = [];


### PR DESCRIPTION
This seems to mitigate a race condition during reconnect that can cause
the client to go into a reconnect-disconnect loop (https://github.com/Atmosphere/atmosphere/issues/1860).

