### PR TITLE
Use connectTimeout setting also for close requests

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -432,6 +432,7 @@
                         connected: false
                     };
                     var closeR = new atmosphere.AtmosphereRequest(rq);
+                    closeR.connectTimeout = _request.connectTimeout;
                     closeR.attachHeadersAsQueryString = false;
                     closeR.dropHeaders = true;
                     closeR.url = url;


### PR DESCRIPTION
Related to disconnect issue described in https://github.com/Atmosphere/atmosphere/issues/1863

Avoids long-running synchronous XHR when an offline client tries to disconnect after it has already lost connection. Could also perhaps just use a hardcoded value for these close requests, in fact there even is a line at https://github.com/Atmosphere/atmosphere-javascript/blob/master/modules/javascript/src/main/webapp/javascript/atmosphere.js#L2529
that sets a 'timeout' property to 1000 for close requests that currently does nothing, perhaps 'connectTimeout' was intended?