### PR TITLE
Fix version header for vanilla JS module.

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2146,7 +2146,7 @@
                 }
 
                 if (!_request.dropHeaders) {
-                    ajaxRequest.setRequestHeader("X-Atmosphere-Framework", atmosphere.util.version);
+                    ajaxRequest.setRequestHeader("X-Atmosphere-Framework", version);
                     ajaxRequest.setRequestHeader("X-Atmosphere-Transport", request.transport);
 
                     if (request.heartbeat !== null && request.heartbeat.server !== null) {


### PR DESCRIPTION
* Don't use atmosphere.util.version, use toplevel
  'version' variable instead.

Pretty straightforward. Using the vanilla JS library was causing the JavascriptProtocol to bomb, because it was sending "undefined" for the X-Atmosphere-Framework header, and then JavascriptProtocol.inspect was doing this:

    String javascriptVersion = request.getHeader(HeaderConfig.X_ATMOSPHERE_FRAMEWORK);
    int version = Integer.valueOf(javascriptVersion.split("-")[0].replace(".", ""));

Which of course bombs when trying to split and parse "undefined".