### PR TITLE
Prevent Firefox's multiple reconnects during navigation away from current page

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -47,7 +47,7 @@
         // ATMOSPHERE-JAVASCRIPT-143: Delay reconnect to avoid reconnect attempts before an actual unload (we don't know if an unload will happen, yet)
         jQuery.atmosphere._beforeUnloadState = true;
         setTimeout(function () {
-            jQuery.atmosphere.util.debug(new Date() + " Atmosphere: " + "beforeunload event timeout reached. Reset _beforeUnloadState flag");
+            jQuery.atmosphere.debug(new Date() + " Atmosphere: " + "beforeunload event timeout reached. Reset _beforeUnloadState flag");
             jQuery.atmosphere._beforeUnloadState = false;
         }, 5000);
     });
@@ -1806,7 +1806,7 @@
                 var reconnectF = function (force){
                     if(jQuery.atmosphere._beforeUnloadState){
                         // ATMOSPHERE-JAVASCRIPT-143: Delay reconnect to avoid reconnect attempts before an actual unload (we don't know if an unload will happen, yet)
-                        jQuery.atmosphere.util.debug(new Date() + " Atmosphere: reconnectF: execution delayed due to _beforeUnloadState flag");
+                        jQuery.atmosphere.debug(new Date() + " Atmosphere: reconnectF: execution delayed due to _beforeUnloadState flag");
                         setTimeout(function () {
                             reconnectFExec(force);
                         }, 5000);


### PR DESCRIPTION
As discussed in #143.

Introducing an internal _beforeUnloadState flag which is set when the beforeunload event occurs. The flag is reset after (currently hardcoded) 5 seconds. If a reconnect occurs when the _beforeUnloadState flag is raised, the reconnect will be delayed for (currently hardcoded) 5 seconds.

The goal is to prevent Firefox's multiple reconnects when the user decides to navigate away from the current page while also supporting reconnect if the navigation link did not lead to an unload event (example when using a download link), i.e. the navigation to a new location was cancelled.

Reason for this time delay approach: As far as I know it is not possible to detect a cancelled navigation attempt, i.e. an attempt that triggered beforeunload but will not trigger unload.

Note: jquery.atmosphere.js has NOT been verified as it is not in use in our application (we use atmosphere.js). Please assist with verification of Firefox using jquery.atmosphere.js.