### PR TITLE
add handleOnlineOffline flag to let atmosphere know if this request n…

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -195,6 +195,7 @@
                 ackInterval: 0,
                 closeAsync: false,
                 reconnectOnServerError: true,
+                handleOnlineOffline: true,
                 onError: function (response) {
                 },
                 onClose: function (response) {
@@ -3443,11 +3444,13 @@
             var requestsClone = [].concat(requests);
             for (var i = 0; i < requestsClone.length; i++) {
                 var rq = requestsClone[i];
-                rq.close();
-                clearTimeout(rq.response.request.id);
+                if(rq.handleOnlineOffline) {
+                    rq.close();
+                    clearTimeout(rq.response.request.id);
 
-                if (rq.heartbeatTimer) {
-                    clearTimeout(rq.heartbeatTimer);
+                    if (rq.heartbeatTimer) {
+                        clearTimeout(rq.heartbeatTimer);
+                    }
                 }
             }
         }
@@ -3457,8 +3460,10 @@
         atmosphere.util.debug(new Date() + " Atmosphere: online event");
         if (requests.length > 0) {
             for (var i = 0; i < requests.length; i++) {
-                requests[i].init();
-                requests[i].execute();
+                if(requests[i].handleOnlineOffline) {
+                    requests[i].init();
+                    requests[i].execute();
+                }
             }
         }
         offline = false;

--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -57,11 +57,13 @@
         var requestsClone = [].concat(jQuery.atmosphere.requests);
         for (var i = 0; i < requestsClone.length; i++) {
             var rq = requestsClone[i];
-            rq.close();
-            clearTimeout(rq.response.request.id);
+            if(rq.handleOnlineOffline) {
+                rq.close();
+                clearTimeout(rq.response.request.id);
 
-            if (rq.heartbeatTimer) {
-                clearTimeout(rq.heartbeatTimer);
+                if (rq.heartbeatTimer) {
+                    clearTimeout(rq.heartbeatTimer);
+                }
             }
         }
     });
@@ -70,8 +72,10 @@
         jQuery.atmosphere.offline = false;
         if (jQuery.atmosphere.requests.length > 0) {
             for (var i = 0; i < jQuery.atmosphere.requests.length; i++) {
-                jQuery.atmosphere.requests[i].init();
-                jQuery.atmosphere.requests[i].execute();
+                if(requests[i].handleOnlineOffline) {
+                    jQuery.atmosphere.requests[i].init();
+                    jQuery.atmosphere.requests[i].execute();
+                }
             }
         }
     });
@@ -239,6 +243,7 @@
                 ackInterval: 0,
                 closeAsync: false,
                 reconnectOnServerError: true,
+                handleOnlineOffline: true,
                 onError: function (response) {
                 },
                 onClose: function (response) {


### PR DESCRIPTION
As part of investigating Atmosphere#176 (still unresolved), I noticed that even under normal circumstances there is duplication at the app level and the library level for dealing with online/offline events.

In my app, there are a number of coordinated actions that need to be handled with online/offline, not just auto reconnecting the websocket. It would be handy for an app to be able to disable atmosphere's default handling in some cases since it generates noise.

Would be happy to adjust this change stylistically.