### PR TITLE
fix bug when the track message size is split into pieces

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1708,6 +1708,15 @@
                             response.messages = [];
                             return true;
                         }
+                    } else {
+                    	/* 
+                    	 * Keep any remaining data even if the message does not contain a valid message.
+                    	 * In case of long message size (for example "10") the partial message could be 1. 
+                    	 */
+                        response.partialMessage = message;
+                        response.responseBody = "";
+                        response.messages = [];
+                        return true;
                     }
                 }
                 response.responseBody = message;

--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1626,6 +1626,15 @@
                             response.messages = [];
                             return true;
                         }
+                    } else {
+                    	/* 
+                    	 * Keep any remaining data even if the message does not contain a valid message.
+                    	 * In case of long message size (for example "10") the partial message could be 1. 
+                    	 */
+                        response.partialMessage = message;
+                        response.responseBody = "";
+                        response.messages = [];
+                        return true;
                     }
                 }
                 response.responseBody = message;


### PR DESCRIPTION
I did experience an issue when using the Primefaces Push-Feature with the atmosphere jquery plugin. We are using the TrackMessageSize-feature in combination with streaming. The messages are between 100 and 125 character long. From time to time the message size is split into two pieces (for example "12" and "4|{userId:....}"). The first piece is ignored because it does not contain the message separator sign. The onMessage() callback is afterwards called with "{use" which can not be processed properly. The feature does not work until the page is reloaded, because the rest of the message is kept in memory.

I hope I could explain the problem properly. If you have further questions don't hesitate to contact me.

Sascha Grebe
