### PR TITLE
Update atmosphere.js to fix Syntax error

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -47,7 +47,7 @@
         hasOwn = Object.prototype.hasOwnProperty;
 
     atmosphere = {
-        version = "2.3.2-javascript",
+        version: "2.3.2-javascript",
         onError: function (response) {
         },
         onClose: function (response) {


### PR DESCRIPTION
`version = "2.3.2-javascript"` throws `Uncaught SyntaxError: Invalid shorthand property initializer`

Property syntax should be `version: "2.3.2-javascript"`