### PR TITLE
Fix streaming reconnect on IE9

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2421,6 +2421,9 @@
                                 }
 
                                 var res = cdoc.body ? cdoc.body.lastChild : cdoc;
+                                if (res.omgThisIsBroken) {
+                                    // Cause an exception when res is null, to trigger a reconnect...
+                                }
                                 var readResponse = function () {
                                     // Clones the element not to disturb the original one
                                     var clone = res.cloneNode(true);


### PR DESCRIPTION
Streaming reconnect fails on IE9 with an exception message
"Unable to get value of the property 'cloneNode': object is null or undefined"

This happens when trying to write a <plaintext> tag to an iframe document when
the iframe fails to load (network error) and later on attempting to use that
tag which was never written.

In the JQuery version, reconnect happened to work as the exception was
accidentally triggered earlier by comparing the node tag name to "pre".
As the node was null, an exception was thrown, but the it was thrown early
enough to be inside a try block so it was caught and handled. This caused
reconnect to work in that version.