### PR TITLE
Allow closing the connection if state is OPEN or CONNECTING

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -519,7 +519,7 @@
                     _activeRequest = null;
                 }
                 if (_websocket != null) {
-                    if (_websocket.readyState === 0 || _websocket.readyState === 1) {
+                    if (_websocket.canSendMessage) {
                         _debug("invoking .close() on WebSocket object");
                         _websocket.close();
                     }
@@ -1688,8 +1688,11 @@
                         while (messageStart !== -1) {
                             var str = message.substring(0, messageStart);
                             var messageLength = +str;
-                            if (isNaN(messageLength))
+                            if (isNaN(messageLength)) {
+                                // Discard partial message, otherwise it would never recover from this condition
+                                response.partialMessage = '';
                                 throw new Error('message length "' + str + '" is not a number');
+                            }
                             messageStart += request.messageDelimiter.length;
                             if (messageStart + messageLength > message.length) {
                                 // message not complete, so there is no trailing messageDelimiter

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -519,7 +519,7 @@
                     _activeRequest = null;
                 }
                 if (_websocket != null) {
-                    if (_websocket.canSendMessage) {
+                    if (_websocket.readyState === 0 || _websocket.readyState === 1) {
                         _debug("invoking .close() on WebSocket object");
                         _websocket.close();
                     }


### PR DESCRIPTION
This was created to fix https://github.com/Atmosphere/atmosphere-javascript/issues/205

Basically if the websocket connectTimeout is triggered, but the connection is still established later, there is no way to close the websocket.

I think we should close it anyway as long as the state is OPEN or CONNECTING
