### PR TITLE
Allow recover if there are 2 messages on the same frame but only the first one with proper length

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -519,7 +519,7 @@
                     _activeRequest = null;
                 }
                 if (_websocket != null) {
-                    if (_websocket.readyState === 0 || _websocket.readyState === 1) {
+                    if (_websocket.canSendMessage) {
                         _debug("invoking .close() on WebSocket object");
                         _websocket.close();
                     }
@@ -1688,8 +1688,11 @@
                         while (messageStart !== -1) {
                             var str = message.substring(0, messageStart);
                             var messageLength = +str;
-                            if (isNaN(messageLength))
+                            if (isNaN(messageLength)) {
+                                // Discard partial message, otherwise it would never recover from this condition
+                                response.partialMessage = '';
                                 throw new Error('message length "' + str + '" is not a number');
+                            }
                             messageStart += request.messageDelimiter.length;
                             if (messageStart + messageLength > message.length) {
                                 // message not complete, so there is no trailing messageDelimiter

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -519,7 +519,7 @@
                     _activeRequest = null;
                 }
                 if (_websocket != null) {
-                    if (_websocket.canSendMessage) {
+                    if (_websocket.readyState === 0 || _websocket.readyState === 1) {
                         _debug("invoking .close() on WebSocket object");
                         _websocket.close();
                     }


### PR DESCRIPTION
This is to handle the specific case when server sends a frame like this (which we are experiencing with atmosphere server)

5|abcdeSomeMoreStuff

In this example, if there is some additional stuff after consuming the 5 initial characters, the clients throws and error, but it enters a state were it never recover from this situation

This at least will discard "SomeMoreStuff" part but allow you to processing the next incoming frames correctly