### PR TITLE
Atmosphere websocket failover

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1536,7 +1536,7 @@
 
                     if (_abortingConnection) {
                         atmosphere.util.log(_request.logLevel, ["Websocket closed normally"]);
-                    } else if (!webSocketOpened) {
+                    } else if (!webSocketOpened && _request.fallbackTransport !== 'websocket') {
                         _reconnectWithFallbackTransport("Websocket failed on first connection attempt. Downgrading to " + _request.fallbackTransport + " and resending");
 
                     } else if (_request.reconnect && _response.transport === 'websocket' ) {
@@ -1740,11 +1740,11 @@
                     atmosphere.util.onTransportFailure(errorMessage, _request);
                 }
 
-                _request.transport = _request.fallbackTransport;
                 var reconnectInterval = _request.connectTimeout === -1 ? 0 : _request.connectTimeout;
                 if (_request.reconnect && _request.transport !== 'none' || _request.transport == null) {
                     _request.method = _request.fallbackMethod;
                     _response.transport = _request.fallbackTransport;
+                    _response.state = '';
                     _request.fallbackTransport = 'none';
                     if (reconnectInterval > 0) {
                         _request.reconnectId = setTimeout(function () {


### PR DESCRIPTION
When both primary and fallback transports are websocket, allow atmosphere
to try and reconnect properly and make a callback when it all fails.

See https://groups.google.com/forum/#!topic/atmosphere-framework/gsE8GjwyPMg also.