### PR TITLE
Support Websockets blocked by CSP

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1475,6 +1475,10 @@
                     if (_request.heartbeatTimer) {
                         clearTimeout(_request.heartbeatTimer);
                     }
+                    
+                    if (_request.fallbackTransport !== 'websocket') {
+                        _reconnectWithFallbackTransport("Websocket connection failed. Downgrading to " + _request.fallbackTransport + " and resending");
+                    }
                 };
 
                 _websocket.onclose = function (message) {

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -196,6 +196,8 @@
                 closeAsync: false,
                 reconnectOnServerError: true,
                 handleOnlineOffline: true,
+                maxWebsocketErrorRetries: 1,
+                curWebsocketErrorRetries: 0,
                 onError: function (response) {
                 },
                 onClose: function (response) {
@@ -485,6 +487,7 @@
                 _response.responseBody = "";
                 _response.status = 408;
                 _response.partialMessage = "";
+                _request.curWebsocketErrorRetries = 0;
                 _invokeCallback();
                 _disconnect();
                 _clearState();
@@ -1476,8 +1479,8 @@
                         clearTimeout(_request.heartbeatTimer);
                     }
                     
-                    if (_request.fallbackTransport !== 'websocket') {
-                        _reconnectWithFallbackTransport("Websocket connection failed. Downgrading to " + _request.fallbackTransport + " and resending");
+                    if (++_request.curWebsocketErrorRetries < _request.maxWebsocketErrorRetries && _request.fallbackTransport !== 'websocket') {
+                        _reconnectWithFallbackTransport("Failed to connect via Websocket. Downgrading to " + _request.fallbackTransport + " and resending");
                     }
                 };
 


### PR DESCRIPTION
If the application supports the Content Security Policy, it is possible - depending on the configuration - that all Websockets or Websockets for specific hosts are blocked on client side. Until now, Atmosphere just raised an error in this case, but it did not switch to the fallback transport.

This PR extends the **onerror** method of the Websocket logic by a reconnect to the fallback transport, e.g. long-polling.