### PR TITLE
Remove support for deprecated synchronous XHR

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -181,7 +181,6 @@
                 reconnectInterval: 0,
                 dropHeaders: true,
                 uuid: 0,
-                async: true,
                 shared: false,
                 readResponsesHeaders: false,
                 maxReconnectOnClose: 5,
@@ -193,7 +192,6 @@
                     server: null
                 },
                 ackInterval: 0,
-                closeAsync: false,
                 reconnectOnServerError: true,
                 handleOnlineOffline: true,
                 maxWebsocketErrorRetries: 1,
@@ -458,7 +456,6 @@
                     if (_request.enableXDR) {
                         closeR.enableXDR = _request.enableXDR
                     }
-                    closeR.async = _request.closeAsync;
                     _pushOnClose("", closeR);
                 }
             }
@@ -1109,7 +1106,6 @@
 
                             script = document.createElement("script");
                             script.src = url + "&jsonpTransport=" + callback;
-                            //script.async = rq.async;
                             script.clean = function () {
                                 script.clean = script.onerror = script.onload = script.onreadystatechange = null;
                                 if (script.parentNode) {
@@ -1749,7 +1745,7 @@
 
                 var reconnectInterval = _request.connectTimeout === -1 ? 0 : _request.connectTimeout;
                 if (_request.reconnect && _request.transport !== 'none' || _request.transport == null) {
-                	_request.transport = _request.fallbackTransport;
+                 _request.transport = _request.fallbackTransport;
                     _request.method = _request.fallbackMethod;
                     _response.transport = _request.fallbackTransport;
                     _response.state = '';
@@ -2171,7 +2167,7 @@
                 url = atmosphere.util.prepareURL(url);
 
                 if (create) {
-                    ajaxRequest.open(request.method, url, request.async);
+                    ajaxRequest.open(request.method, url, true);
                     if (request.connectTimeout > 0) {
                         request.id = setTimeout(function () {
                             if (request.requestCount === 0) {
@@ -2671,7 +2667,6 @@
                     logLevel: 'info',
                     requestCount: 0,
                     withCredentials: _request.withCredentials,
-                    async: _request.async,
                     transport: 'polling',
                     isOpen: true,
                     attachHeadersAsQueryString: true,

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1745,7 +1745,7 @@
 
                 var reconnectInterval = _request.connectTimeout === -1 ? 0 : _request.connectTimeout;
                 if (_request.reconnect && _request.transport !== 'none' || _request.transport == null) {
-                 _request.transport = _request.fallbackTransport;
+                    _request.transport = _request.fallbackTransport;
                     _request.method = _request.fallbackMethod;
                     _response.transport = _request.fallbackTransport;
                     _response.state = '';


### PR DESCRIPTION
I have received some browser warnings in Chrome because there is still the possibility to define wheter the XHR will act in a asynchronous or synchronous way. In my opionen, in 2017, we should go only the async way and drop the support for sync XHR.

Removing this option suffices my needs and works as expected in all the following browsers:

- Chrome 59 Windows
- Firefox 55
- Edge 14
- Internet Explorer 10 & 11