### PR TITLE
Better error message on websocket connection timeout

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -1387,7 +1387,7 @@
                         if (!webSocketOpened) {
                             var _message = {
                                 code: 1002,
-                                reason: "",
+                                reason: "Connection timeout after " + _request.connectTimeout + "ms.",
                                 wasClean: false
                             };
                             _websocket.onclose(_message);


### PR DESCRIPTION
On websocket connection timeout, the message is:
"The endpoint is terminating the connection due to a protocol error."
But it is not what append when the connection opening hang.
So I propose to set a better message

Fix bug #252