### PR TITLE
Fix exception when sendBeacon is not available

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -196,7 +196,7 @@
                 handleOnlineOffline: true,
                 maxWebsocketErrorRetries: 1,
                 curWebsocketErrorRetries: 0,
-                unloadBackwardCompat: false,
+                unloadBackwardCompat: !navigator.sendBeacon,
                 onError: function (response) {
                 },
                 onClose: function (response) {

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2595,7 +2595,7 @@
                 rq.force = true;
                 rq.suspend = false;
                 rq.timeout = 1000;
-                if (rq.unloadBackwardCompat) {
+                if (_request.unloadBackwardCompat) {
                     _executeRequest(rq);
                 } else {
                     navigator.sendBeacon(rq.url, rq.data);


### PR DESCRIPTION
The sendBeacon can be disabled in Firefox and is not supported in IE, so this commit update the defaut unloadBackwardCompat value according the sendBeacon browser support to prevent exception.

Moreother, this parameter is undefined in the \_pushOnClose function