### PR TITLE
Add a warn in log when longpolling was unable to connect

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2023,6 +2023,9 @@
                             }
 
                             if (status >= 300 || status === 0) {
+                                if (!rq.isOpen && _canLog('warn')) {
+                                   atmosphere.util.warn(rq.transport + " connection failed with status: " + status + " " + (ajaxRequest.statusText || "Unable to connect"));
+                                }
                                 disconnected();
                                 return;
                             }


### PR DESCRIPTION
This allows us to see the long-pooling reconnections in the log