### PR TITLE
Avoid errors when sending message during websocket reconnection

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2624,7 +2624,7 @@
                 } else if (_websocket != null) {
                     _pushWebSocket(message);
                 // Avoid errors when sending message during websocket reconnection
-                } else if (_request && _request.isOpen && _request.reconnect && _request.transport === "websocket") {
+                } else if (_request && _request.isOpen && _request.reconnect && _request.isReopen && _request.transport === "websocket") {
                     _debug("Waiting for the websocket reconnection to send the message...");
                     var reopenHandler = _request.onReopen;
                     _request.onReopen = function() {

--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -2623,6 +2623,17 @@
                     _pushJsonp(message);
                 } else if (_websocket != null) {
                     _pushWebSocket(message);
+                // Avoid errors when sending message during websocket reconnection
+                } else if (_request && _request.isOpen && _request.reconnect && _request.transport === "websocket") {
+                    _debug("Waiting for the websocket reconnection to send the message...");
+                    var reopenHandler = _request.onReopen;
+                    _request.onReopen = function() {
+                        _request.onReopen = reopenHandler;
+                        if (typeof (reopenHandler) !== 'undefined') {
+                            reopenHandler.apply(this, arguments);
+                        }
+                        _push(message, _request);
+                    }
                 } else {
                     _onError(0, "No suspended connection available");
                     atmosphere.util.error("No suspended connection available. Make sure atmosphere.subscribe has been called and request.onOpen invoked before trying to push data");


### PR DESCRIPTION
If we have a reverse proxy, who close the websocket after one minute, if we try to send a message during the reconnect interval, the error "No suspended connection available" is fired.
This patch wait for the websocket reconnection to send the message.