### PR TITLE
The onOpen() callback function may not be called after error + online event

### DIFF
--- a/modules/javascript/src/main/webapp/javascript/atmosphere.js
+++ b/modules/javascript/src/main/webapp/javascript/atmosphere.js
@@ -3559,6 +3559,7 @@
             if (requests.length > 0) {
                 for (var i = 0; i < requests.length; i++) {
                     if (requests[i].request.handleOnlineOffline) {
+						requests[i].response.error = false;
                         requests[i].init();
                         requests[i].execute();
                     }


### PR DESCRIPTION
Trying to make an offline mode for my application, I noticed:

The request.onOpen() callback function may not be called after the online event if the response.error is true.

1. To reproduce on android, disconnect wifi and mobile data
2. Wait for a connection error and the onerror() callback
3. Re-enable wifi/mobile data
4. The connection reopen fined, but my application is not noticed by the onopen() callback
5. Due to the  _invokeCallback(); instruction (line 1067) not called in the _open() function when response.error is true